### PR TITLE
chore: update pnpm settings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,8 +6,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
-        with:
-          version: 8.6.0
       - uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,15 +4,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
           version: 8.6.0
       - uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v5
         with:
           path: |
             ${{ github.workspace }}/.next/cache

--- a/package.json
+++ b/package.json
@@ -55,5 +55,6 @@
   "lint-staged": {
     "*.{js,ts,tsx}": "eslint --cache --fix",
     "*.{js,ts,tsx,css,md,json}": "prettier --write"
-  }
+  },
+  "packageManager": "pnpm@10.28.1"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+blockExoticSubdeps: true
+minimumReleaseAge: 1440 # 24h
+trustPolicy: no-downgrade


### PR DESCRIPTION
## Summary
- Update pnpm to version 10.28.1
- Add pnpm-workspace.yaml security settings:
  - `blockExoticSubdeps: true`
  - `minimumReleaseAge: 1440` (24h)
  - `trustPolicy: no-downgrade`